### PR TITLE
[BINF-687] Disable Picard SplitVcf strict mode 

### DIFF
--- a/tools/picard_split_vcfs.cwl
+++ b/tools/picard_split_vcfs.cwl
@@ -66,4 +66,4 @@ outputs:
     secondaryFiles:
       - ".idx"
 
-baseCommand: [java, -Xmx4G, -jar, /usr/local/bin/picard.jar, SplitVcfs]
+baseCommand: [java, -Xmx4G, -jar, /usr/local/bin/picard.jar, SplitVcfs, STRICT=false]


### PR DESCRIPTION
The GATK4 mutect2 WGS VCFs can contain MNPs, which cause errors with the default `STRICT=true` behavior.

Either this change or an additional MNP-filtering step is needed.